### PR TITLE
add an integration test for mindy

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,36 @@
+package mindy
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+type Client struct {
+	Addr   string
+	client *http.Client
+}
+
+func (c *Client) Post(r *Request) (*Results, error) {
+	if c.client == nil {
+		c.client = http.DefaultClient
+	}
+	bod, err := json.Marshal(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "encoding request")
+	}
+	resp, err := c.client.Post("http://"+c.Addr+"/mindy", "application/json", bytes.NewBuffer(bod))
+	if err != nil {
+		return nil, errors.Wrap(err, "making request")
+	}
+	if resp.StatusCode > 299 {
+		return nil, errors.Errorf("unexpected response status code: %d", resp.StatusCode)
+	}
+	dec := json.NewDecoder(resp.Body)
+	res := &Results{}
+	err = dec.Decode(res)
+
+	return res, errors.Wrap(err, "decoding response")
+}

--- a/mindy_test.go
+++ b/mindy_test.go
@@ -1,0 +1,113 @@
+package mindy
+
+import (
+	"testing"
+
+	"github.com/pilosa/go-pilosa"
+
+	ptest "github.com/pilosa/pilosa/test"
+)
+
+func TestMindy(t *testing.T) {
+	server := ptest.MustNewRunningServer(t)
+	populate(t, server.Server.Addr().String())
+
+	m := NewMain()
+
+	m.Pilosa = []string{server.Server.Addr().String()}
+	m.Bind = "localhost:33333"
+	err := m.listen()
+	if err != nil {
+		t.Fatalf("m.listen: %v", err)
+	}
+
+	go m.serve()
+
+	client := Client{
+		Addr: m.Bind,
+	}
+
+	tests := []struct {
+		req      *Request
+		expected *Results
+	}{
+		{
+			req: &Request{
+				Indexes:     []string{"p1", "two", "p3"},
+				Includes:    []Row{{ID: 0, Frame: "f1"}, {ID: 0, Frame: "f2"}},
+				Excludes:    []Row{},
+				Conjunction: "and",
+			},
+			expected: &Results{
+				Bits: map[string][]uint64{
+					"p1":  bits(1, 2),
+					"two": []uint64{},
+					"p3":  bits(3, 6),
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		res, err := client.Post(test.req)
+		if err != nil {
+			t.Fatalf("making request %d: %v", i, err)
+		}
+		if err := res.Equals(test.expected); err != nil {
+			t.Fatalf("inequality test %d: %v", i, err)
+		}
+	}
+}
+
+func populate(t *testing.T, host string) {
+	client, err := pilosa.NewClientFromAddresses([]string{host}, nil)
+	if err != nil {
+		t.Fatalf("getting client: %v", err)
+	}
+
+	indexes := []string{"p1", "two", "p3", "p4"}
+	for i, idx := range indexes {
+		i := uint64(i)
+		sch, err := client.Schema()
+		if err != nil {
+			t.Fatalf("getting schema: %v", err)
+		}
+
+		index, err := sch.Index(idx, nil)
+		if err != nil {
+			t.Fatalf("getting index: %v", err)
+		}
+
+		f1, err := index.Frame("f1", nil)
+		f2, err := index.Frame("f2", nil)
+
+		err = client.SyncSchema(sch)
+		if err != nil {
+			t.Fatalf("syncing schema: %v", err)
+		}
+
+		bq := index.BatchQuery()
+		for row := uint64(0); row < 5; row++ {
+			for bit := uint64(0); bit < 100; bit += 1 + i + row {
+				bq.Add(f1.SetBit(row, bit))
+				if bit%2 == 1 {
+					bq.Add(f2.SetBit(row, bit))
+				}
+			}
+		}
+		_, err = client.Query(bq, nil)
+		if err != nil {
+			t.Fatalf("querying: %v", err)
+		}
+
+	}
+
+}
+
+func bits(start, step uint64) []uint64 {
+	res := make([]uint64, 0)
+	for i := start; i < 100; i += step {
+		res = append(res, i)
+	}
+	return res
+}


### PR DESCRIPTION
Starts up a Pilosa, populates it with data, starts mindy, and then makes a mindy
request and checks the response.

Adds a tiny mindy client as a helper. More invasively, refactors mindy to
separate listening from serving to avoid a race condition in the test.
Technically, just doing `go main.Run()` and then querying mindy is a race since
the server is not guaranteed to be listening if requests are run after that. By
splitting into separate listen and serve methods, we are able to ensure that the
operating system will accept the connection regardless of whether the `go
main.serve()` goroutine has been run yet.